### PR TITLE
fix for non-positive size parameter

### DIFF
--- a/function.partition.php
+++ b/function.partition.php
@@ -1,5 +1,14 @@
 <?php
 function smarty_function_partition($params, $template, $test = false) {
+
+    if ((int) $params['size'] <= 0) {
+        if (!$test) {
+            $template->assign($params['name'], []);
+        } else {
+            return [$params['name'] => []];
+        }
+    }
+
     $listlen   = count($params['array']);
     $partlen   = floor($listlen / $params['size']);
     $partrem   = $listlen % $params['size'];

--- a/test.php
+++ b/test.php
@@ -7,9 +7,14 @@ class Test extends PHPUnit_Framework_TestCase {
 		return smarty_function_partition($a, null, true);
 	}
 
-	public function testEmpty()
+    public function testEmpty()
     {
         $this->assertEquals(['test' => [[],[],[]]], $this->wrapper(['array' => null, 'name' => 'test', 'size' => 3]));
+    }
+
+    public function testZeroColumns()
+    {
+        $this->assertEquals(['test' => []], $this->wrapper(['array' => null, 'name' => 'test', 'size' => 0]));
     }
 
 	public function testPerfectFit()


### PR DESCRIPTION
Return an empty array instead of failing
